### PR TITLE
Fix an error when fetch_res[k] is None

### DIFF
--- a/envkey/loader.py
+++ b/envkey/loader.py
@@ -28,7 +28,8 @@ def load(is_init=False, cache_enabled=None, dot_env_enabled=True, dot_env_path="
 
   for k in fetch_res:
     if os.environ.get(k) == None:
-      os.environ[k] = fetch_res[k]
-      vars_set[k] = fetch_res[k]
+      if k is not None and fetch_res[k] is not None:
+        os.environ[k] = fetch_res[k]
+        vars_set[k] = fetch_res[k]
 
   return vars_set


### PR DESCRIPTION
This was causing my gunicorn workers to fail to start with the exception below. It would probably be better fixed with a try / except but without being to familiar with the code I needed the quick fix and I imagine other users might too.
```
Traceback (most recent call last):
  File "/srv/www/venv3/lib/python3.6/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/srv/www/venv3/lib/python3.6/site-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/srv/www/venv3/lib/python3.6/site-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/srv/www/venv3/lib/python3.6/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/srv/www/venv3/lib/python3.6/site-packages/gunicorn/app/wsgiapp.py", line 52, in load
    return self.load_wsgiapp()
  File "/srv/www/venv3/lib/python3.6/site-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/srv/www/venv3/lib/python3.6/site-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
  File "/srv/www/od/config/wsgi.py", line 13, in <module>
    import envkey  # NOQA
  File "/srv/www/venv3/src/envkey/envkey/__init__.py", line 4, in <module>
    load(is_init=True)
  File "/srv/www/venv3/src/envkey/envkey/loader.py", line 32, in load
    os.environ[k] = fetch_res[k]
  File "/srv/www/venv3/lib/python3.6/os.py", line 674, in __setitem__
    value = self.encodevalue(value)
  File "/srv/www/venv3/lib/python3.6/os.py", line 744, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not NoneType
```