### PR TITLE
Adds syntactic sugar `get`

### DIFF
--- a/envkey/__init__.py
+++ b/envkey/__init__.py
@@ -1,6 +1,9 @@
 from .loader import load
 from .fetch import fetch_env
+from os import environ
+
+get = environ.get
 
 load(is_init=True)
 
-__all__ = ['load', 'fetch_env']
+__all__ = ['load', 'fetch_env', 'get']


### PR DESCRIPTION
Adds a get function to the module to allow users to call envkey.get('VARNAME') as syntactic sugar. The get function is just pointed at os.environ.get.